### PR TITLE
10 add support for custom ffmpeg and ffprobe paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,19 +51,19 @@ There are two main ways to create stickers:
         quality: 50, // Output quality (1-100)
         background: "#000000" // Background color
     });
-    
+
     // Convert to buffer
     const buffer = await sticker.toBuffer();
-    
+
     // Save to file
     await sticker.toFile("sticker.webp");
-    
+
     // Send using Baileys-MD
     conn.sendMessage(jid, await sticker.toMessage());
     ```
 
     You can also chain methods for better readability:
-    
+
     ```js
     const buffer = await new Sticker(image)
         .setPack("My Pack")
@@ -171,6 +171,25 @@ You can specify a background color in two ways:
 
 ---
 
+## Configuration
+
+You can set custom paths for `ffmpeg` and `ffprobe` using the config system:
+
+```js
+const { config } = require("wa-sticker-toolkit");
+
+config.setConfig({
+    ffmpegPath: "/custom/path/to/ffmpeg",
+    ffprobePath: "/custom/path/to/ffprobe"
+});
+
+// use config.getConfig() to get config Object
+```
+
+If not set, the toolkit assumes `ffmpeg` and `ffprobe` are available in your system's PATH.
+
+---
+
 ## WhatsApp Sticker Metadata
 
 WhatsApp stickers include metadata such as the pack name, author, and categories.
@@ -178,9 +197,9 @@ WhatsApp stickers include metadata such as the pack name, author, and categories
 1. Author & Pack Title
 
     <img src="https://i.ibb.co/9vmxsKd/metadata.jpg" alt="Metadata example" width="256"/>
-    
+
     Bold text: Pack title
-    
+
     Remaining text: Author name
 
     > This metadata is stored using Exif data embedded in the WebP file.

--- a/package.json
+++ b/package.json
@@ -1,17 +1,24 @@
 {
     "name": "wa-sticker-toolkit",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "A package to create stickers for WhatsApp.",
     "main": "src/index.js",
     "scripts": {
         "test": "echo \"Error: no test at the moment, I'm to lazy to do so now.\" && exit 0"
     },
-    "files": ["src"],
+    "files": [
+        "src"
+    ],
     "repository": {
         "type": "git",
         "url": "git+https://github.com/DannyAkintunde/wa-sticker-toolkit.git"
     },
-    "keywords": ["sticker", "whatsapp", "WhatsApp-stickers", "webp"],
+    "keywords": [
+        "sticker",
+        "whatsapp",
+        "WhatsApp-stickers",
+        "webp"
+    ],
     "author": "DannyAkintunde",
     "license": "MIT",
     "bugs": {

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,14 @@
+let config = {};
+
+function getConfig() {
+    return config;
+}
+
+function setConfig(newConfig) {
+    config = { ...config, ...newConfig };
+}
+
+module.exports = {
+    getConfig,
+    setConfig
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,10 @@
 "use strict";
 
+const config = require("./config");
 const { Sticker, createSticker } = require("./Sticker");
 const { StickerTypes } = require("./lib/StickerTypes");
 const { TextPositions } = require("./lib/addTextToMedia");
 
 global.DEBUG = false;
 
-module.exports = { Sticker, createSticker, StickerTypes, TextPositions };
+module.exports = { Sticker, createSticker, StickerTypes, TextPositions, config };

--- a/src/lib/addTextToMedia.js
+++ b/src/lib/addTextToMedia.js
@@ -1,6 +1,7 @@
 const ffmpeg = require("fluent-ffmpeg");
 const fs = require("fs");
 const tmp = require("tmp");
+const { getConfig } = require("../config");
 
 const TextPositions = Object.freeze({
     TOP: "top",
@@ -31,7 +32,9 @@ function addTextToMedia(inputBuffer, content, options = {}, isVideo) {
     const outputFile = tmp.fileSync({ postfix: ext });
 
     fs.writeFileSync(inputFile.name, inputBuffer);
-
+    
+    const { ffmpegPath } = getConfig();
+    if (ffmpegPath) ffmpeg.setFfmpegPath(ffmpegPath);
     return new Promise((resolve, reject) => {
         ffmpeg(inputFile.name)
             .output(outputFile.name)

--- a/src/lib/converter.js
+++ b/src/lib/converter.js
@@ -2,6 +2,7 @@ const fs = require("fs");
 const sharp = require("sharp");
 const ffmpeg = require("fluent-ffmpeg");
 const tmp = require("tmp");
+const { getConfig } = require("../config");
 
 async function imageToWebp(media) {
     const tmpFileOut = tmp.fileSync({ postfix: ".webp" });
@@ -9,6 +10,8 @@ async function imageToWebp(media) {
 
     fs.writeFileSync(tmpFileIn.name, media);
 
+    const { ffmpegPath } = getConfig();
+    if (ffmpegPath) ffmpeg.setFfmpegPath(ffmpegPath);
     await new Promise((resolve, reject) => {
         ffmpeg(tmpFileIn.name)
             .on("error", err => {
@@ -61,6 +64,8 @@ async function videoToWebp(media, quality) {
 
     fs.writeFileSync(tmpFileIn.name, media);
 
+    const { ffmpegPath } = getConfig();
+    if (ffmpegPath) ffmpeg.setFfmpegPath(ffmpegPath);
     await new Promise((resolve, reject) => {
         ffmpeg(tmpFileIn.name)
             .on("error", err => {
@@ -109,6 +114,8 @@ async function videoToMov(media, stickerLength, frameRate) {
 
     fs.writeFileSync(tmpFileIn.name, media);
 
+    const { ffmpegPath } = getConfig();
+    if (ffmpegPath) ffmpeg.setFfmpegPath(ffmpegPath);
     await new Promise((resolve, reject) => {
         ffmpeg(tmpFileIn.name)
             .on("error", err => {

--- a/src/lib/internal/mediaProcessor.js
+++ b/src/lib/internal/mediaProcessor.js
@@ -4,6 +4,7 @@ const fs = require("fs");
 const tmp = require("tmp");
 const TempFiles = require("../helpers/TempFiles");
 const { createSvgMaskAndBorder } = require("./svgMaskOverlay");
+const { getConfig } = require("../../config")
 
 /**
  * Generates a PNG mask file from the SVG mask.
@@ -199,6 +200,8 @@ function processFilters(
     quality,
     isVideo
 ) {
+    const { ffmpegPath } = getConfig();
+    if (ffmpegPath) ffmpeg.setFfmpegPath(ffmpegPath);
     return new Promise((resolve, reject) => {
         const process = ffmpeg(inputPath)
             .complexFilter(filterComplex)
@@ -236,6 +239,8 @@ function processFilters(
 }
 
 function getDimensions(videoPath) {
+    const { ffprobePath } = getConfig();
+    ffmpeg.setFfprobePath(ffprobePath);
     return new Promise((resolve, reject) => {
         ffmpeg.ffprobe(videoPath, (err, metadata) => {
             if (err) reject(err);


### PR DESCRIPTION
This PR adds `setConfig({ ffmpegPath, ffprobePath })` to allow custom ffmpeg/probe paths for environments where they're not globally accessible.